### PR TITLE
InitVar is now properly type-checked for dataclass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
     env: exclude_file_pattern=nothing
     dist: xenial
     sudo: true
+  - name: "3.8 Unit Test"
+    python: "3.8"
+    env: exclude_file_pattern=nothing
+    dist: xenial
+    sudo: true
 install:
   - python3 -m pip install pylint
   - python3 -m pip install mypy

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="undictify",
-    version="0.6.5",
+    version="0.7.0",
     author="Tobias Hermann",
     author_email="editgym@gmail.com",
     description="Type-checked function calls at runtime",
@@ -16,6 +16,7 @@ setuptools.setup(
     classifiers=(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ),

--- a/undictify/_unpack.py
+++ b/undictify/_unpack.py
@@ -304,9 +304,17 @@ def _get_dict_value(func: Callable[..., TypeT], value: Any,
 
 
 def _is_initvar_type(the_type: Callable[..., TypeT]) -> bool:
-    """Return True if the type is an InitVar"""
+    """Return True if the type is an InitVar
+
+    In Python 3.7, InitVar is essentially a singleton.
+        InitVar[str] == InitVar[int]
+    In Python 3.8, InitVar can be a singleton, or an instance.
+        InitVar[str] != InitVar[int], but InitVar == InitVar
+
+    Therefore, the code below checks for both cases to support 3.7 and 3.8
+    """
     if VER_3_7_AND_UP:
-        return the_type == InitVar
+        return the_type == InitVar or isinstance(the_type, InitVar)
     return False
 
 

--- a/undictify/_unpack.py
+++ b/undictify/_unpack.py
@@ -194,6 +194,9 @@ def _get_value(func: WrappedOrFunc[TypeT],  # pylint: disable=too-many-arguments
                skip_superfluous: bool, convert_types: bool,
                converters: Optional[Dict[str, Callable[[Any], Any]]]) -> Any:
     """Convert a single value into target type if possible."""
+    if _is_initvar_type(func):
+        return value
+
     if _is_list(value):
         return _get_list_value(func, value, param_name,
                                skip_superfluous, convert_types,
@@ -203,9 +206,6 @@ def _get_value(func: WrappedOrFunc[TypeT],  # pylint: disable=too-many-arguments
         # Use settings of inner value
         return _get_dict_value(func, value, skip_superfluous, convert_types,
                                converters)
-
-    if _is_initvar_type(func):
-        return value
 
     allowed_types = list(map(_unwrap_decorator_type, _get_union_types(func) \
         if _is_optional_type(func) or _is_union_type(func) \
@@ -269,6 +269,7 @@ def _get_list_value(func: Callable[..., TypeT],  # pylint: disable=too-many-argu
                     converters: Optional[Dict[str, Callable[[Any], Any]]]) -> Any:
     if not _is_list_type(func) and \
             not _is_optional_list_type(func):
+        print(func)
         raise TypeError(f'No list expected for {log_name}')
     result = []
     result_elem_type = _get_list_type_elem_type(func)

--- a/undictify/_unpack.py
+++ b/undictify/_unpack.py
@@ -269,7 +269,6 @@ def _get_list_value(func: Callable[..., TypeT],  # pylint: disable=too-many-argu
                     converters: Optional[Dict[str, Callable[[Any], Any]]]) -> Any:
     if not _is_list_type(func) and \
             not _is_optional_list_type(func):
-        print(func)
         raise TypeError(f'No list expected for {log_name}')
     result = []
     result_elem_type = _get_list_type_elem_type(func)

--- a/undictify/_unpack.py
+++ b/undictify/_unpack.py
@@ -67,7 +67,7 @@ def type_checked_constructor(skip: bool = False,
             func.__new__ = wrapper(func.__new__, signature_new)  # type: ignore
         else:
             func.__init__ = wrapper(func.__init__, _get_signature(func.__init__))  # type: ignore
-            if is_dataclass(func) and hasattr(func, '__post_init__'):
+            if _is_dataclass(func) and hasattr(func, '__post_init__'):
                 func.__post_init__ = wrapper(func.__post_init__, _get_signature(func.__post_init__))  # type: ignore
         setattr(func, '__undictify_wrapped_func__', func)
         return func
@@ -446,6 +446,13 @@ def _is_builtin_type(the_type: Callable[..., TypeT]) -> bool:
 def _is_none_type(value: TypeT) -> bool:
     """Return True if the value is of NoneType."""
     return value is type(None)
+
+
+def _is_dataclass(value: TypeT) -> bool:
+    """Return True if the value is a dataclass"""
+    if VER_3_7_AND_UP:
+        return is_dataclass(value)
+    return False
 
 
 def _is_dict(value: TypeT) -> bool:


### PR DESCRIPTION
In Python dataclasses, InitVars are passed as arguments to __init__ and
__post_init__. Unfortunately, as of Python 3.7, InitVar does not pass
any type information regarding its contained type. For example, these is
not way to determine that InitVar[str] contains a str. InitVar is
currently defined as following in the Python standard library:

  class _InitVarMeta(type):
      def __getitem__(self, params):
          return self

  class InitVar(metaclass=_InitVarMeta):
      pass

As such, it is missing the __args__ attribute found on container classes
in the typing module. InitVars are passed as arguements to __init__ but
are not set there. Their type is InitVar, so we choose to simply ignore
their type (for now) and pass the value through __init__ if it is an
InitVar.

Because of this limitation, we rely on the __post_init__ method to
determine the type of an InitVar. We provide a check for __post_init__
method arguments. Any arguments passed to this method are assumed to be
InitVars defined for the data class. Their types can be annotated in
__post_init__, and the annotations are used to perform runtime type
checks on the InitVar.

Our treatment of InitVar could result in strange edge case bugs. This is
documented in the tests (see: test_known_bug_initvar_as_argument_passes)

Resolves: https://github.com/Dobiasd/undictify/issues/12