### PR TITLE
Distinguish between optional and mandatory converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ from undictify import type_checked_constructor
 def parse_timestamp(datetime_repr: str) -> datetime:
     return datetime.strptime(datetime_repr, '%Y-%m-%dT%H:%M:%SZ')
 
-@type_checked_constructor(converters={'some_timestamp': parse_timestamp})
+@type_checked_constructor(converters={'some_timestamp': optional_converter(parse_timestamp)})
 @dataclass
 class Foo:
     some_timestamp: datetime
@@ -265,6 +265,10 @@ class Foo:
 json_repr = '{"some_timestamp": "2019-06-28T07:20:34Z"}'
 my_foo = Foo(**json.loads(json_repr))
 ```
+
+In case the converter should be applied even if the source type
+already matches the destination type, use `mandatory_converter`
+instead of `optional_converter`.
 
 
 Requirements and Installation

--- a/examples/readme_examples.py
+++ b/examples/readme_examples.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 from typing import List, NamedTuple, Optional, Any
 
-from undictify import type_checked_constructor
+from undictify import type_checked_constructor, optional_converter
 
 __author__ = "Tobias Hermann"
 __copyright__ = "Copyright 2018, Tobias Hermann"
@@ -80,7 +80,7 @@ def parse_timestamp(datetime_repr: str) -> datetime:
     return datetime.strptime(datetime_repr, '%Y-%m-%dT%H:%M:%SZ')
 
 
-@type_checked_constructor(converters={'some_timestamp': parse_timestamp})
+@type_checked_constructor(converters={'some_timestamp': optional_converter(parse_timestamp)})
 class Foo(NamedTuple):
     some_timestamp: datetime
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="undictify",
-    version="0.7.1",
+    version="0.8.0",
     author="Tobias Hermann",
     author_email="editgym@gmail.com",
     description="Type-checked function calls at runtime",

--- a/undictify/__init__.py
+++ b/undictify/__init__.py
@@ -1,4 +1,4 @@
-from ._unpack import type_checked_call, type_checked_constructor
+from ._unpack import type_checked_call, type_checked_constructor, optional_converter, mandatory_converter
 
 name = "undictify"
 

--- a/undictify/tests.py
+++ b/undictify/tests.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union, Tuple
 from typing import TypeVar
 
+from ._unpack import optional_converter, mandatory_converter
 from ._unpack import type_checked_call, type_checked_constructor
 
 TypeT = TypeVar('TypeT')
@@ -1149,6 +1150,11 @@ def parse_timestamp(datetime_repr: str) -> datetime:
     return datetime.strptime(datetime_repr, '%b %d %Y %I:%M%p')
 
 
+def concat_changed_to_string(value: str) -> str:
+    """value + '_changed'"""
+    return value + '_changed'
+
+
 def forward_str(str_repr: str) -> str:
     """Forward string argument."""
     return str_repr
@@ -1175,18 +1181,20 @@ class HasMemberNeedingCustomConverter(NamedTuple):
 class TestCustomConverter(unittest.TestCase):
     """Sometimes pythons default conversions are not enough."""
 
-    def test_datetime_ok(self) -> None:
+    def test_datetime_ok_optional(self) -> None:
         """Valid JSON string."""
         object_repr = '{"msg": "hi", "timestamp": "Jun 1 2005  1:33PM"}'
-        obj = type_checked_call(converters={'timestamp': parse_timestamp})(NeedingCustomConverter)(
-            **json.loads(object_repr))
+        obj = type_checked_call(converters={
+            'timestamp': optional_converter(parse_timestamp)
+        })(NeedingCustomConverter)(**json.loads(object_repr))
         self.assertEqual('hi', obj.msg)
         self.assertEqual(datetime(2005, 6, 1, 13, 33), obj.timestamp)
 
-    def test_datetime_already_converted(self) -> None:
+    def test_datetime_already_converted_optional(self) -> None:
         """Valid JSON string."""
-        obj = type_checked_call(converters={'timestamp': parse_timestamp})(NeedingCustomConverter)(
-            **{"msg": "hi", "timestamp": datetime(2005, 6, 1, 13, 33)})
+        obj = type_checked_call(converters={
+            'timestamp': optional_converter(parse_timestamp)
+        })(NeedingCustomConverter)(**{"msg": "hi", "timestamp": datetime(2005, 6, 1, 13, 33)})
         self.assertEqual('hi', obj.msg)
         self.assertEqual(datetime(2005, 6, 1, 13, 33), obj.timestamp)
 
@@ -1194,15 +1202,53 @@ class TestCustomConverter(unittest.TestCase):
         """Custom converters shall only be applied to the outer call."""
         object_repr = '{"needs_conversion": {"msg": "hi", "timestamp": "Jun 1 2005  1:33PM"}}'
         with self.assertRaises(TypeError):
-            type_checked_call(converters={'timestamp': parse_timestamp})(
-                HasMemberNeedingCustomConverter)(**json.loads(object_repr))
+            type_checked_call(converters={
+                'timestamp': optional_converter(parse_timestamp)
+            })(HasMemberNeedingCustomConverter)(**json.loads(object_repr))
 
-    def test_invalid_converter_result_type(self) -> None:
+    def test_invalid_converter_result_type_optional(self) -> None:
         """Valid JSON string, but incorrect converter."""
         object_repr = '{"msg": "hi", "timestamp": "Jun 1 2005  1:33PM"}'
         with self.assertRaises(TypeError):
-            type_checked_call(converters={'timestamp': forward_str})(NeedingCustomConverter)(
-                **json.loads(object_repr))
+            type_checked_call(converters={
+                'timestamp': optional_converter(forward_str)
+            })(NeedingCustomConverter)(**json.loads(object_repr))
+
+    def test_datetime_ok_mandatory(self) -> None:
+        """Valid JSON string."""
+        object_repr = '{"msg": "hi", "timestamp": "Jun 1 2005  1:33PM"}'
+        obj = type_checked_call(converters={
+            'timestamp': mandatory_converter(parse_timestamp)
+        })(NeedingCustomConverter)(**json.loads(object_repr))
+        self.assertEqual('hi', obj.msg)
+        self.assertEqual(datetime(2005, 6, 1, 13, 33), obj.timestamp)
+
+    def test_datetime_already_converted_mandatory_ok(self) -> None:
+        """Valid JSON string, but should fail."""
+        obj_unchanged = type_checked_call(converters={
+            'msg': optional_converter(concat_changed_to_string)
+        })(NeedingCustomConverter)(**{"msg": "hi", "timestamp": datetime(2005, 6, 1, 13, 33)})
+        self.assertEqual('hi', obj_unchanged.msg)
+
+        obj_changed = type_checked_call(converters={
+            'msg': mandatory_converter(concat_changed_to_string)
+        })(NeedingCustomConverter)(**{"msg": "hi", "timestamp": datetime(2005, 6, 1, 13, 33)})
+        self.assertEqual('hi_changed', obj_changed.msg)
+
+    def test_datetime_already_converted_mandatory_fail(self) -> None:
+        """Valid JSON string, but should fail."""
+        with self.assertRaises(TypeError):
+            type_checked_call(converters={
+                'timestamp': mandatory_converter(parse_timestamp)
+            })(NeedingCustomConverter)(**{"msg": "hi", "timestamp": datetime(2005, 6, 1, 13, 33)})
+
+    def test_invalid_converter_result_type_mandatory(self) -> None:
+        """Valid JSON string, but incorrect converter."""
+        object_repr = '{"msg": "hi", "timestamp": "Jun 1 2005  1:33PM"}'
+        with self.assertRaises(TypeError):
+            type_checked_call(converters={
+                'timestamp': mandatory_converter(forward_str)
+            })(NeedingCustomConverter)(**json.loads(object_repr))
 
 
 @type_checked_constructor()


### PR DESCRIPTION
These changes allow the user to decide if the usage of a custom converter should be optional or mandatory (see related discussion in [issue 15](https://github.com/Dobiasd/undictify/issues/15)).

@richin13 and/or @LukeMathWalker if you'd like to have a quick look before we merge, that would be cool. :)